### PR TITLE
Fix memory leak, when the entire document is minified away.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension CSS::Minifier::XS.
 
 {{$NEXT}}
+    - Fixes a memory leak in minify(), when the entire document is minified
+      away.
 
 0.13      2021-02-06 17:26:39-08:00 America/Vancouver
     - Internals; avoid allocating memory for each node as we tokenize the

--- a/XS.xs
+++ b/XS.xs
@@ -658,7 +658,7 @@ Node* CssPruneNodes(Node *head) {
  * ****************************************************************************
  */
 char* CssMinify(const char* string) {
-    char* results;
+    char* results = NULL;
     CssDoc doc;
 
     /* initialize our CSS document object */
@@ -672,12 +672,12 @@ char* CssMinify(const char* string) {
 
     /* PASS 1: tokenize CSS into a list of nodes */
     Node* head = CssTokenizeString(&doc, string);
-    if (!head) return NULL;
+    if (!head) goto cleanup;
     /* PASS 2: collapse nodes */
     CssCollapseNodes(head);
     /* PASS 3: prune nodes */
     head = CssPruneNodes(head);
-    if (!head) return NULL;
+    if (!head) goto cleanup;
     /* PASS 4: re-assemble CSS into single string */
     {
         Node* curr;
@@ -697,6 +697,7 @@ char* CssMinify(const char* string) {
         *ptr = 0;
     }
     /* free memory used by the NodeSets */
+    cleanup:
     {
         NodeSet* curr = doc.head_set;
         while (curr) {

--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,6 @@ author_requires 'File::Which';
 author_requires 'IPC::Run';
 author_requires 'CSS::Compressor';
 author_requires 'CSS::Minifier';
+author_requires 'Linux::Smaps';
 author_requires 'Number::Format';
 author_requires 'Test::LeakTrace';

--- a/xt/author/leaks-xs.t
+++ b/xt/author/leaks-xs.t
@@ -1,0 +1,60 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use CSS::Minifier::XS qw(minify);
+
+BEGIN {
+  eval "use Linux::Smaps";
+  plan skip_all => "Linux::Smaps required for XS leak testing" if $@;
+}
+use Linux::Smaps;
+
+###############################################################################
+my $ITERS_WARMUP  = 100;
+my $ITERS_TESTING = 5_000;
+
+###############################################################################
+# CSS input that triggers the leak: a string that minifies down to no nodes.
+my $css = '/* */';
+
+###############################################################################
+# Sanity check: minify() of the test CSS returns nothing (as it was all
+# minified away).
+is minify($css), undef, 'minify() of empty CSS returns undef';
+
+###############################################################################
+# Warm things up.  Runs a handful of iterations so that our memory allocator
+# can reach a steady state.
+minify($css) for (1 .. $ITERS_WARMUP);
+
+###############################################################################
+# Measure RSS growth over repeated calls to the minifier.  If the XS code is
+# leaking any memory, our RSS should grow.
+my $smaps = Linux::Smaps->new;
+
+my $rss_before = $smaps->update->rss;
+minify($css) for (1 .. $ITERS_TESTING);
+my $rss_after = $smaps->update->rss;
+
+my $rss_growth = $rss_after - $rss_before;
+note sprintf(
+  "RSS before: %d KB, after: %d KB, growth: %d KB over %d calls (%.3f KB/call)",
+  $rss_before,
+  $rss_after,
+  $rss_growth,
+  $ITERS_TESTING,
+  $rss_growth / $ITERS_TESTING,
+);
+
+###############################################################################
+# Allow for some memory allocator noise and fragmentation.
+#
+# If total growth exceeds this threshold, odds are high that we're leaking.
+my $THRESHOLD_KB = 4_000;
+cmp_ok $rss_growth, '<', $THRESHOLD_KB,
+  "minify() does not leak memory (RSS growth $rss_growth KB < $THRESHOLD_KB KB)";
+
+###############################################################################
+done_testing();


### PR DESCRIPTION

When the entire CSS document is minified away, `minify()` would leak
memory without bounds.  Fix this by ensuring that even when we have
nothing left to return, that we do proper cleanup and free any memory
which we have allocated.
