### PR TITLE
Fix zero collapsing

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for Perl extension CSS::Minifier::XS.
 0.14      2026-06-28 16:30:59-07:00 America/Vancouver
     - Fixes a memory leak in minify(), when the entire document is minified
       away.
+    - Fix bug which resulted in zeroes being collapsed when they shouldn't,
+      affecting filenames with zeroes in them (e.g.  "url(status-0.png)").
+      Thanks to Stefan Berger for reporting GH#5.
 
 0.13      2021-02-06 17:26:39-08:00 America/Vancouver
     - Internals; avoid allocating memory for each node as we tokenize the

--- a/XS.xs
+++ b/XS.xs
@@ -528,6 +528,19 @@ void CssCollapseNodes(Node* curr) {
                 if (!nodeIsNumber(curr))
                     break;
 
+                /* numerics can be part of a NAME or PATH segment, instead of
+                 * being an actual numeric value (e.g. ".grid-001",
+                 * "--spacing-001", "url(cache/00/foo.png)").  Those need to be
+                 * preserved.
+                 */
+                if (curr->prev
+                    && (nodeIsCHAR(curr->prev, '-') || nodeIsCHAR(curr->prev, '/'))
+                    && curr->prev->prev
+                    && nodeIsIDENTIFIER(curr->prev->prev))
+                {
+                    break;
+                }
+
                 /* skip all leading zeros */
                 ptr = CssSkipZeroValue(curr->contents);
 

--- a/XS.xs
+++ b/XS.xs
@@ -219,6 +219,52 @@ bool nodeStartsBANGIMPORTANT(Node* node) {
     return 0;
 }
 
+/* checks if this node contains a numeric value: an optional leading run of
+ * digits, followed by an optional single decimal point, which MUST be followed
+ * by a digit, and an optional trailing unit (letters and/or "%").
+ *
+ * NOTE: "node->contents" may not be NULL terminated (it is a pointer into a
+ * pre-existing string value), so iterate using "->contents" and "->length".
+ */
+bool nodeIsNumber(Node* node) {
+    const char* p   = node->contents;
+    const char* end = p + node->length;
+    bool sawDigit = 0;
+
+    /* leading run of digits */
+    while ((p < end) && charIsNumeric(*p)) {
+        sawDigit = 1;
+        p++;
+    }
+
+    /* decimal point, which MUST be followed by a digit */
+    if ((p < end) && (*p == '.')) {
+        p++;
+        /* no trailing digit? Then not a number */
+        if ((p >= end) || !charIsNumeric(*p))
+            return 0;
+        /* skip past all following digits */
+        while ((p < end) && charIsNumeric(*p))
+            p++;
+        sawDigit = 1;
+    }
+
+    /* must have seen at least one digit, otherwise it's not a number */
+    if (!sawDigit)
+        return 0;
+
+    /* optional trailing unit: letters and/or "%" only */
+    while (p < end) {
+        char ch = *p++;
+        if ( ((ch>='a')&&(ch<='z')) || ((ch>='A')&&(ch<='Z')) || (ch=='%') )
+            continue;
+        return 0;
+    }
+
+    /* looks sane; it's a number */
+    return 1;
+}
+
 /* ****************************************************************************
  * NODE MANIPULATION FUNCTIONS
  * ****************************************************************************
@@ -474,16 +520,13 @@ void CssCollapseNodes(Node* curr) {
                 break;
             case NODE_IDENTIFIER:
             {
-                /* if the node doesn't begin with a "zero", nothing to collapse */
-                const char* ptr = curr->contents;
-                if ( (*ptr != '0') && (*ptr != '.' )) {
-                    /* not "0" and not "point-something" */
+                const char* ptr;
+
+                /* if the node isn't numeric, there's no point trying to
+                 * collapse a Zero (as it won't have any).
+                 */
+                if (!nodeIsNumber(curr))
                     break;
-                }
-                if ( (*ptr == '.') && (*(ptr+1) != '0') ) {
-                    /* "point-something", but not "point-zero" */
-                    break;
-                }
 
                 /* skip all leading zeros */
                 ptr = CssSkipZeroValue(curr->contents);

--- a/t/minify-collapse-zeroes.t
+++ b/t/minify-collapse-zeroes.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use CSS::Minifier::XS qw(minify);
+
+###############################################################################
+# When collapsing "zeroes", we ONLY want to collapse ones that are genuine
+# numeric values.  We should NOT be collapsing identifier/filename fragments
+# that simply happen to begin with a "0" (e.g. "status-0.png").
+subtest 'identifiers w/zeroes are preserved' => sub {
+  is minify('a{background:url(0.png)}'),            'a{background:url(0.png)}',            'paren: 0.png';
+  is minify('a{background:url(001.png)}'),          'a{background:url(001.png)}',          'paren: 001.png';
+  is minify('a{background:url(img/0.png)}'),        'a{background:url(img/0.png)}',        'slash: img/0.png';
+  is minify('a{background:url(a.png),url(0.png)}'), 'a{background:url(a.png),url(0.png)}', 'comma list: 0.png';
+};
+
+###############################################################################
+# Double-check that numeric values collapse as expected.
+#
+# While yes, this is somewhat duplicative to tests already done in "minify.t",
+# I'm leaving them here as well for mental context.
+subtest 'numeric values collapse as expected' => sub {
+  is minify('a{margin:0px}'),            'a{margin:0}',             '0px -> 0';
+  is minify('a{opacity:0.5}'),           'a{opacity:.5}',           '0.5 -> .5';
+  is minify('a{opacity:0.50}'),          'a{opacity:.50}',          '0.50 -> .50';
+  is minify('a{margin:0.0px}'),          'a{margin:0}',             '0.0px -> 0';
+  is minify('a{color:rgba(0,0,0,0.5)}'), 'a{color:rgba(0,0,0,.5)}', 'rgba alpha 0.5 -> .5';
+};
+
+###############################################################################
+done_testing();

--- a/t/minify-collapse-zeroes.t
+++ b/t/minify-collapse-zeroes.t
@@ -17,6 +17,23 @@ subtest 'identifiers w/zeroes are preserved' => sub {
 };
 
 ###############################################################################
+# Verify that leading-zeroes in identifiers are preserved.
+subtest 'leading zeroes in identifiers are preserved' => sub {
+  is minify('.grid-001{color:red}'),       '.grid-001{color:red}',       'class .grid-001';
+  is minify('.icon-007{color:red}'),       '.icon-007{color:red}',       'class .icon-007';
+  is minify('#item-001{color:red}'),       '#item-001{color:red}',       'id #item-001';
+  is minify(':root{--spacing-001:5px}'),   ':root{--spacing-001:5px}',   'custom property name';
+  is minify('a{animation-name:spin-001}'), 'a{animation-name:spin-001}', 'animation name';
+};
+
+###############################################################################
+# Verify that leading-zeroes in url() paths are preserved
+subtest 'leading zeroes in url() paths are preserved' => sub {
+  is minify('a{background:url(cache/00/x.png)}'),  'a{background:url(cache/00/x.png)}',  'numeric cache dir /00/';
+  is minify('a{background:url(v1/007/icon.png)}'), 'a{background:url(v1/007/icon.png)}', 'numeric path segment /007/';
+};
+
+###############################################################################
 # Double-check that numeric values collapse as expected.
 #
 # While yes, this is somewhat duplicative to tests already done in "minify.t",
@@ -26,6 +43,8 @@ subtest 'numeric values collapse as expected' => sub {
   is minify('a{opacity:0.5}'),           'a{opacity:.5}',           '0.5 -> .5';
   is minify('a{opacity:0.50}'),          'a{opacity:.50}',          '0.50 -> .50';
   is minify('a{margin:0.0px}'),          'a{margin:0}',             '0.0px -> 0';
+  is minify('a{margin:0px}'),            'a{margin:0}',             '0px -> 0';
+  is minify('a{margin:-0.5px}'),         'a{margin:-.5px}',         'negative -0.5px -> -.5px';
   is minify('a{color:rgba(0,0,0,0.5)}'), 'a{color:rgba(0,0,0,.5)}', 'rgba alpha 0.5 -> .5';
 };
 


### PR DESCRIPTION
Fixes how zeroes are collapsed/minified, to ensure that we are not accidentally
dropping zeroes when they are part of an identifier/filename/path.

Addresses #5

- **Add (failing) test for collapsing zeroes.**
- **Do not collapse zeroes when they are part of an identifier.**
- **Add (failing) test cases for zeroes in identifiers/filenames.**
- **Ensure numerics in names/paths are preserved.**
